### PR TITLE
Add support for static RadioCapabilities.

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -342,4 +342,9 @@
     <!-- enable doze powersaving mode -->
     <bool name="config_enableAutoPowerModes">true</bool>
 
+    <!-- The RadioAccessFamilies supported by the device.
+         Empty is viewed as "all".  Only used on devices which
+         don't support RIL_REQUEST_GET_RADIO_CAPABILITY
+         format is UMTS|LTE|... -->
+    <string translatable="false" name="config_radio_access_family">GSM | WCDMA | LTE | CDMA | EVDO</string>
 </resources>


### PR DESCRIPTION
Some RILs don't support RIL_REQUEST_GET_RADIO_CAPABILITY.  Add
code to RIL.java to notice a REQUEST_NOT_SUPPORTED response and
check config.xml (config_radio_access_family) for a static answer.

Also catching GENERIC_FAILURE responses because Hammerhead modem
returns that.  B 21079604 created for this.

If neither Modem nor config.xml provide data, uses RAF_UNKNOWN
so we don't lie about capabilities and also so we fail fast
(setPreferredNetwork won't work).

bug:20561357
Change-Id: Icd4558a203de6ff11c7f00d040d2d187df207af9